### PR TITLE
feat: memtable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "bytes"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +64,7 @@ name = "chipmunk"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "bytes",
  "chrono",
  "serde",
  "tempdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 bincode = "1.3.3"
+bytes = { version = "1.6.1", features = ["serde"] }
 chrono = "0.4.38"
 serde = { version = "1.0.204", features = ["derive"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
+mod memtable;
 mod wal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
-mod memtable;
 mod lsm;
+mod memtable;
 mod wal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 mod memtable;
+mod lsm;
 mod wal;

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -1,0 +1,8 @@
+use std::path::Path;
+
+use crate::{memtable::Memtable, wal::Wal};
+
+pub struct LSM<P: AsRef<Path>> {
+    wal: Wal<P>,
+    memtable: Memtable,
+}

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -2,7 +2,8 @@ use std::path::Path;
 
 use crate::{memtable::Memtable, wal::Wal};
 
-pub struct LSM<P: AsRef<Path>> {
+#[allow(dead_code)]
+pub struct Lsm<P: AsRef<Path>> {
     wal: Wal<P>,
     memtable: Memtable,
 }

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -161,18 +161,26 @@ mod test {
         }
 
         // Remove key0 and key6
-        wal.append(WalEntry::Delete {
-            key: b"key0".to_vec(),
-        });
-        wal.append(WalEntry::Delete {
-            key: b"key6".to_vec(),
-        });
+        let deletions = vec![
+            WalEntry::Delete {
+                key: b"key0".to_vec(),
+            },
+            WalEntry::Delete {
+                key: b"key6".to_vec(),
+            },
+            WalEntry::Delete {
+                key: b"key3".to_vec(),
+            },
+        ];
+        for d in deletions {
+            wal.append(d);
+        }
 
         let mut m = Memtable::new(0, MEMTABLE_MAX_SIZE_BYTES);
         m.load(wal);
 
         for i in 0..10 {
-            if i == 0 || i == 6 {
+            if i == 0 || i == 6 || i == 3 {
                 assert!(m.get(format!("key{i}").as_bytes()).is_none());
                 continue;
             }

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -4,7 +4,7 @@
 use std::{
     collections::BTreeMap,
     fs::File,
-    io::{BufReader, Read, Write},
+    io::{BufReader, Read},
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
 };
@@ -90,18 +90,16 @@ impl Memtable {
         self.tree = BTreeMap::new();
         self.current_size = 0;
 
-        let mut f = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(format!(
+        std::fs::write(
+            format!(
                 "{}/sstable-{}",
                 flush_dir.display(),
                 self.id.load(Ordering::Acquire)
-            ))
-            .unwrap();
-
+            ),
+            data,
+        )
+        .unwrap();
         self.id.fetch_add(1, Ordering::Relaxed);
-        f.write_all(&data).unwrap();
     }
 }
 

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -61,7 +61,7 @@ impl Memtable {
             .create(true)
             .open(format!("{}/sstable-1", flush_dir.display()))
             .unwrap();
-        f.write(&data).unwrap();
+        f.write_all(&data).unwrap();
     }
 }
 

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -160,16 +160,19 @@ mod test {
             });
         }
 
-        // Remove
+        // Remove key0 and key6
         wal.append(WalEntry::Delete {
             key: b"key0".to_vec(),
+        });
+        wal.append(WalEntry::Delete {
+            key: b"key6".to_vec(),
         });
 
         let mut m = Memtable::new(0, MEMTABLE_MAX_SIZE_BYTES);
         m.load(wal);
 
         for i in 0..10 {
-            if i == 0 {
+            if i == 0 || i == 6 {
                 assert!(m.get(format!("key{i}").as_bytes()).is_none());
                 continue;
             }

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -1,0 +1,9 @@
+// TODO: remove once used in other components
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+
+pub struct Memtable {
+    // TODO: contained types
+    tree: BTreeMap<(), ()>,
+}

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -3,7 +3,62 @@
 
 use std::collections::BTreeMap;
 
+use bytes::Bytes;
+
+pub const MEMTABLE_MAX_SIZE_BYTES: u64 = 1048576; // 1 MiB
+
 pub struct Memtable {
-    // TODO: contained types
-    tree: BTreeMap<(), ()>,
+    tree: BTreeMap<bytes::Bytes, bytes::Bytes>,
+
+    max_size: u64,
+}
+
+impl Memtable {
+    pub fn new(max_size: u64) -> Self {
+        Self {
+            tree: BTreeMap::new(),
+            max_size,
+        }
+    }
+
+    pub fn put(&mut self, key: &'static [u8], value: &'static [u8]) {
+        let key = Bytes::from_static(key);
+        let value = Bytes::from_static(value);
+        self.tree.insert(key, value);
+    }
+
+    pub fn get(&self, key: &[u8]) -> Option<&[u8]> {
+        match self.tree.get(key) {
+            Some(v) => Some(v),
+            None => None,
+        }
+    }
+
+    pub fn delete(&mut self, key: &[u8]) -> Result<(), &'static str> {
+        match self.tree.remove(key) {
+            Some(_) => Ok(()),
+            None => Err("cannot remove nonexistent key"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Memtable, MEMTABLE_MAX_SIZE_BYTES};
+
+    #[test]
+    fn crud_operations() {
+        let mut m = Memtable::new(MEMTABLE_MAX_SIZE_BYTES);
+        m.put(b"foo", b"bar");
+
+        assert_eq!(
+            m.get(b"foo"),
+            Some("bar".as_bytes()),
+            "Expected key to exist after put"
+        );
+
+        assert!(m.delete(b"foo").is_ok());
+        assert!(m.get(b"foo").is_none());
+        assert!(m.delete(b"foo").is_err());
+    }
 }

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -1,7 +1,7 @@
 // TODO: remove once used in other components
 #![allow(dead_code)]
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, io::Write, path::PathBuf};
 
 use bytes::Bytes;
 
@@ -10,6 +10,7 @@ pub const MEMTABLE_MAX_SIZE_BYTES: u64 = 1048576; // 1 MiB
 pub struct Memtable {
     tree: BTreeMap<bytes::Bytes, bytes::Bytes>,
 
+    current_size: u64,
     max_size: u64,
 }
 
@@ -17,16 +18,20 @@ impl Memtable {
     pub fn new(max_size: u64) -> Self {
         Self {
             tree: BTreeMap::new(),
+            current_size: 0,
             max_size,
         }
     }
 
+    /// Put a key-value pair into the [`Memtable`].
     pub fn put(&mut self, key: &'static [u8], value: &'static [u8]) {
         let key = Bytes::from_static(key);
         let value = Bytes::from_static(value);
+        self.current_size += (key.len() + value.len()) as u64;
         self.tree.insert(key, value);
     }
 
+    /// Get a key-value pair from the [`Memtable`].
     pub fn get(&self, key: &[u8]) -> Option<&[u8]> {
         match self.tree.get(key) {
             Some(v) => Some(v),

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -99,6 +99,10 @@ impl<P: AsRef<Path>> Wal<P> {
         // This returns the previous, so we add one to it to get the new value.
         self.id.fetch_add(1, Ordering::Acquire) + 1
     }
+
+    pub fn size(&self) -> u64 {
+        self.current_size
+    }
 }
 
 #[cfg(test)]

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -8,7 +8,7 @@ use std::{fs::File, sync::atomic::AtomicU64};
 
 use serde::{Deserialize, Serialize};
 
-pub const WAL_MAX_SIZE: u64 = 1048576; // 1 MiB
+pub const WAL_MAX_SIZE_BYTES: u64 = 1048576; // 1 MiB
 
 /// Wal maintains a write-ahead log (WAL) as an append-only file to provide persistence
 /// across crashes of the system.
@@ -124,7 +124,7 @@ mod test {
     #[test]
     fn write_to_wal() {
         let temp_dir = TempDir::new("write_wal").unwrap();
-        let mut wal = Wal::new(0, temp_dir, WAL_MAX_SIZE);
+        let mut wal = Wal::new(0, temp_dir, WAL_MAX_SIZE_BYTES);
 
         let wrote = wal.append(b"foo", b"bar");
         assert_eq!(wal.current_size, wrote);
@@ -139,7 +139,7 @@ mod test {
     #[test]
     fn next_id() {
         let temp_dir = TempDir::new("write_wal").unwrap();
-        let wal = Wal::new(0, temp_dir, WAL_MAX_SIZE);
+        let wal = Wal::new(0, temp_dir, WAL_MAX_SIZE_BYTES);
         assert_eq!(wal.next_id(), 1);
         assert_eq!(wal.next_id(), 2);
     }
@@ -147,7 +147,7 @@ mod test {
     #[test]
     fn id() {
         let temp_dir = TempDir::new("write_wal").unwrap();
-        let wal = Wal::new(0, temp_dir, WAL_MAX_SIZE);
+        let wal = Wal::new(0, temp_dir, WAL_MAX_SIZE_BYTES);
         assert_eq!(wal.id(), 0);
         assert_eq!(wal.next_id(), 1);
     }
@@ -155,7 +155,7 @@ mod test {
     #[test]
     fn wal_path() {
         let temp_dir = TempDir::new("write_wal").unwrap();
-        let wal = Wal::new(0, &temp_dir, WAL_MAX_SIZE);
+        let wal = Wal::new(0, &temp_dir, WAL_MAX_SIZE_BYTES);
         assert_eq!(
             wal.path(),
             temp_dir.path().join("0.wal"),


### PR DESCRIPTION
Progress against https://github.com/jdockerty/chipmunk/issues/2

- Introduce `Memtable` for in-memory structure.
- Flush `Memtable` to disk for SSTable representation.
- Replay WAL from disk to populate `Memtable`.