### PR TITLE
feat: basic lsm structure

### DIFF
--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -1,9 +1,96 @@
+#![allow(dead_code)]
+
 use std::path::Path;
 
-use crate::{memtable::Memtable, wal::Wal};
+use crate::{
+    memtable::{Memtable, MEMTABLE_MAX_SIZE_BYTES},
+    wal::{Wal, WalEntry},
+};
 
-#[allow(dead_code)]
 pub struct Lsm<P: AsRef<Path>> {
     wal: Wal<P>,
     memtable: Memtable,
+}
+
+pub struct WalConfig<P: AsRef<Path>> {
+    id: u64,
+    max_size: u64,
+    log_directory: P,
+}
+
+pub struct MemtableConfig {
+    id: u64,
+    max_size: u64,
+}
+
+impl<P: AsRef<Path>> Lsm<P> {
+    pub fn new(wal_config: WalConfig<P>, memtable_config: MemtableConfig) -> Self {
+        Self {
+            wal: Wal::new(wal_config.id, wal_config.log_directory, wal_config.max_size),
+            memtable: Memtable::new(memtable_config.id, memtable_config.max_size),
+        }
+    }
+
+    /// Put an item into the [`Lsm`] tree.
+    ///
+    /// A [`WalEntry`] is appended into the WAL before proceeding to insert the
+    /// key-value pair into an in-memory index, the L0 [`Memtable`].
+    pub fn put(&mut self, key: &'static [u8], value: &'static [u8]) {
+        let entry = WalEntry::Put {
+            key: key.to_vec(),
+            value: value.to_vec(),
+        };
+        self.wal.append(entry);
+
+        self.memtable.put(key, value);
+        if self.memtable.size() >= MEMTABLE_MAX_SIZE_BYTES {
+            self.memtable.flush("".into());
+        }
+    }
+
+    /// Get a key and corresponding value from the LSM-tree.
+    ///
+    /// This first checks whether the value exists in the [`Memtable`] and continues
+    /// the search through persisted SSTables if it does not. After exhausting
+    /// all options, the value does not exist.
+    ///
+    /// TODO: Improve retrieval through use of a bloom filter
+    pub fn get(&mut self, key: &'static [u8]) -> Option<&[u8]> {
+        match self.memtable.get(&key) {
+            Some(v) => Some(v),
+            None => {
+                // TODO: search through sstables
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use tempdir::TempDir;
+
+    use crate::{memtable::MEMTABLE_MAX_SIZE_BYTES, wal::WAL_MAX_SIZE_BYTES};
+
+    use super::{Lsm, MemtableConfig, WalConfig};
+
+    #[test]
+    fn crud() {
+        let dir = TempDir::new("crud").unwrap();
+        let w = WalConfig {
+            id: 0,
+            max_size: WAL_MAX_SIZE_BYTES,
+            log_directory: dir.path(),
+        };
+        let m = MemtableConfig {
+            id: 0,
+            max_size: MEMTABLE_MAX_SIZE_BYTES,
+        };
+        let mut lsm = Lsm::new(w, m);
+
+        lsm.put(b"foo", b"bar");
+
+        assert!(lsm.get(b"foo").is_some());
+        assert_eq!(lsm.get(b"foo").unwrap(), b"bar");
+    }
 }

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -1,15 +1,26 @@
 #![allow(dead_code)]
 
-use std::path::Path;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use bytes::Bytes;
 
 use crate::{
-    memtable::{Memtable, MEMTABLE_MAX_SIZE_BYTES},
+    memtable::Memtable,
     wal::{Wal, WalEntry},
 };
 
 pub struct Lsm<P: AsRef<Path>> {
     wal: Wal<P>,
+
+    /// Active [`Memtable`]
     memtable: Memtable,
+
+    /// IDs of sealed memtables
+    /// TODO: hold these in memory too, so that I/O is greatly reduced?
+    sealed_memtables: Vec<u64>,
+
+    working_directory: PathBuf,
 }
 
 pub struct WalConfig<P: AsRef<Path>> {
@@ -24,10 +35,13 @@ pub struct MemtableConfig {
 }
 
 impl<P: AsRef<Path>> Lsm<P> {
-    pub fn new(wal_config: WalConfig<P>, memtable_config: MemtableConfig) -> Self {
+    pub fn new(id: u64, max_size: u64, working_directory: P) -> Self {
+        let dir = PathBuf::from(working_directory.as_ref());
         Self {
-            wal: Wal::new(wal_config.id, wal_config.log_directory, wal_config.max_size),
-            memtable: Memtable::new(memtable_config.id, memtable_config.max_size),
+            wal: Wal::new(id, working_directory, max_size),
+            memtable: Memtable::new(id, max_size),
+            sealed_memtables: Vec::new(),
+            working_directory: dir,
         }
     }
 
@@ -35,7 +49,7 @@ impl<P: AsRef<Path>> Lsm<P> {
     ///
     /// A [`WalEntry`] is appended into the WAL before proceeding to insert the
     /// key-value pair into an in-memory index, the L0 [`Memtable`].
-    pub fn put(&mut self, key: &'static [u8], value: &'static [u8]) {
+    pub fn put(&mut self, key: Vec<u8>, value: Vec<u8>) {
         let entry = WalEntry::Put {
             key: key.to_vec(),
             value: value.to_vec(),
@@ -43,9 +57,11 @@ impl<P: AsRef<Path>> Lsm<P> {
         self.wal.append(entry);
 
         self.memtable.put(key, value);
-        if self.memtable.size() >= MEMTABLE_MAX_SIZE_BYTES {
-            self.memtable.flush("".into());
-        }
+    }
+
+    pub fn rotate_memtable(&mut self) {
+        self.sealed_memtables.push(self.memtable.id());
+        self.memtable.flush(self.working_directory.clone());
     }
 
     /// Get a key and corresponding value from the LSM-tree.
@@ -55,11 +71,24 @@ impl<P: AsRef<Path>> Lsm<P> {
     /// all options, the value does not exist.
     ///
     /// TODO: Improve retrieval through use of a bloom filter
-    pub fn get(&mut self, key: &'static [u8]) -> Option<&[u8]> {
-        match self.memtable.get(&key) {
-            Some(v) => Some(v),
+    pub fn get(&mut self, key: &'static [u8]) -> Option<Vec<u8>> {
+        match self.memtable.get(key) {
+            Some(v) => Some(v.to_vec()),
             None => {
-                // TODO: search through sstables
+                for memtable_id in self.sealed_memtables.iter().rev() {
+                    let data = std::fs::read(
+                        self.working_directory
+                            .join(format!("sstable-{memtable_id}")),
+                    )
+                    .expect("Previously sealed memtable file should exist");
+                    let memtable: BTreeMap<Bytes, Bytes> = bincode::deserialize(&data).unwrap();
+                    match memtable.get(key) {
+                        Some(v) => return Some(v.to_vec()),
+                        None => continue,
+                    };
+                }
+                // Exhausted search of entire structure did not find the key, so
+                // it does not exist.
                 None
             }
         }
@@ -70,27 +99,28 @@ impl<P: AsRef<Path>> Lsm<P> {
 mod test {
     use tempdir::TempDir;
 
-    use crate::{memtable::MEMTABLE_MAX_SIZE_BYTES, wal::WAL_MAX_SIZE_BYTES};
-
-    use super::{Lsm, MemtableConfig, WalConfig};
+    use super::Lsm;
 
     #[test]
     fn crud() {
         let dir = TempDir::new("crud").unwrap();
-        let w = WalConfig {
-            id: 0,
-            max_size: WAL_MAX_SIZE_BYTES,
-            log_directory: dir.path(),
-        };
-        let m = MemtableConfig {
-            id: 0,
-            max_size: MEMTABLE_MAX_SIZE_BYTES,
-        };
-        let mut lsm = Lsm::new(w, m);
+        let mut lsm = Lsm::new(0, 10, dir.path());
 
-        lsm.put(b"foo", b"bar");
-
+        lsm.put(b"foo".to_vec(), b"bar".to_vec());
+        assert_eq!(lsm.memtable.id(), 0);
         assert!(lsm.get(b"foo").is_some());
         assert_eq!(lsm.get(b"foo").unwrap(), b"bar");
+
+        lsm.rotate_memtable();
+        assert_eq!(
+            lsm.memtable.id(),
+            1,
+            "Engine should have a new memtable after flush"
+        );
+        assert_eq!(
+            lsm.get(b"foo"),
+            Some(b"bar".to_vec()),
+            "Value should be found in sstable on disk"
+        );
     }
 }

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -96,6 +96,10 @@ impl Memtable {
         .unwrap();
         self.id.fetch_add(1, Ordering::Relaxed);
     }
+
+    pub fn size(&self) -> u64 {
+        self.current_size
+    }
 }
 
 #[cfg(test)]

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -20,7 +20,10 @@ pub struct Memtable {
     id: AtomicU64,
     tree: BTreeMap<Bytes, Bytes>,
 
-    current_size: u64,
+    /// Approximate size of the [`Memtable`]. This is an approximation as it simply
+    /// uses the values to increment size - simply because for most cases the values
+    /// are going to be far larger than identifying keys.
+    approximate_size: AtomicU64,
     max_size: u64,
 }
 
@@ -29,7 +32,7 @@ impl Memtable {
         Self {
             id: AtomicU64::new(id),
             tree: BTreeMap::new(),
-            current_size: 0,
+            approximate_size: AtomicU64::new(0),
             max_size,
         }
     }
@@ -56,7 +59,8 @@ impl Memtable {
     pub fn put(&mut self, key: &'static [u8], value: &'static [u8]) {
         let key = Bytes::from_static(key);
         let value = Bytes::from_static(value);
-        self.current_size += (key.len() + value.len()) as u64;
+        self.approximate_size
+            .fetch_add(value.len() as u64, Ordering::Acquire);
         self.tree.insert(key, value);
     }
 
@@ -83,7 +87,9 @@ impl Memtable {
         let data = bincode::serialize(&self.tree).unwrap();
 
         self.tree = BTreeMap::new();
-        self.current_size = 0;
+        // Flushing should happen after a put, therefore the "happens-before"
+        // relationship is maintained here. So we can use Relaxed.
+        self.approximate_size.store(0, Ordering::Relaxed);
 
         std::fs::write(
             format!(
@@ -98,7 +104,12 @@ impl Memtable {
     }
 
     pub fn size(&self) -> u64 {
-        self.current_size
+        self.approximate_size.load(Ordering::Acquire)
+    }
+
+    /// Number of elements (keys) within the [`Memtable`].
+    pub fn len(&self) -> u64 {
+        self.tree.len() as u64
     }
 }
 
@@ -135,9 +146,13 @@ mod test {
         let mut m = Memtable::new(0, MEMTABLE_MAX_SIZE_BYTES);
         let flush_dir = TempDir::new("flush").unwrap();
         m.put(b"foo", b"bar");
-        assert_eq!(m.current_size, b"foobar".len() as u64);
+        assert_eq!(
+            m.size(),
+            b"bar".len() as u64,
+            "Size should be approximated based on values"
+        );
         m.flush(flush_dir.path().to_path_buf());
-        assert_eq!(m.current_size, 0, "New memtable should have size of 0");
+        assert_eq!(m.size(), 0, "New memtable should have size of 0");
         assert!(m.tree.is_empty(), "New memtable should be empty");
 
         let sstable_file =

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -111,6 +111,10 @@ impl Memtable {
         self.approximate_size.load(Ordering::Acquire)
     }
 
+    pub fn max_size(&self) -> u64 {
+        self.max_size
+    }
+
     /// Number of elements (keys) within the [`Memtable`].
     pub fn len(&self) -> u64 {
         self.tree.len() as u64


### PR DESCRIPTION
Progresses https://github.com/jdockerty/chipmunk/issues/2 and https://github.com/jdockerty/chipmunk/issues/9

Introduce a basic `Lsm` structure through the use of a WAL, Memtable, and SSTables. This is a simple two-component LSM-tree.

This does **NOT** include compaction.