### PR TITLE
feat: compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ dependencies = [
  "chrono",
  "serde",
  "tempdir",
+ "walkdir",
 ]
 
 [[package]]
@@ -220,6 +221,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +275,16 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -337,6 +357,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +376,15 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ serde = { version = "1.0.204", features = ["derive"] }
 
 [dev-dependencies]
 tempdir = "0.3.7"
+walkdir = "2.5.0"

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -73,6 +73,7 @@ impl<P: AsRef<Path> + Clone> Lsm<P> {
 
         self.memtable.put(key, value);
         if self.memtable.size() > self.memtable_config.max_size {
+            eprintln!("Memtable rotation");
             self.rotate_memtable()
         }
     }
@@ -121,6 +122,10 @@ impl<P: AsRef<Path> + Clone> Lsm<P> {
         // Delete the in-memory value if it exists.
         let _ = self.memtable.delete(key.as_slice());
         Ok(())
+    }
+
+    pub fn memtable_id(&self) -> u64 {
+        self.memtable.id()
     }
 }
 

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -230,7 +230,7 @@ mod test {
 
         let mut current_size = dir.path().metadata().unwrap().len();
 
-        for i in 1..=5 {
+        for i in 1..=3 {
             for j in 0..=1000 {
                 // The same key value is used, but overwritten on different
                 // iterations to force entries which should be discarded.
@@ -251,6 +251,7 @@ mod test {
         lsm.force_compaction();
         let post_compaction_size = dir.path().metadata().unwrap().len();
 
+        println!("Post: {post_compaction_size}, Final: {final_size}");
         assert!(post_compaction_size < final_size);
         assert_ne!(
             lsm.memtable_id(),

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -231,7 +231,7 @@ mod test {
         let mut current_size = dir.path().metadata().unwrap().len();
 
         for i in 1..=5 {
-            for j in 0..=10_000 {
+            for j in 0..=1000 {
                 // The same key value is used, but overwritten on different
                 // iterations to force entries which should be discarded.
                 let key = format!("key{j}").as_bytes().to_vec();
@@ -243,10 +243,7 @@ mod test {
                     lsm.delete(key);
                 }
 
-                let new_size = dir.path().metadata().unwrap().len();
-                if new_size >= current_size {
-                    current_size = new_size;
-                }
+                current_size = dir.path().metadata().unwrap().len();
             }
         }
 

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -69,7 +69,7 @@ impl Memtable {
         self.tree.insert(key, Some(value));
     }
 
-    /// Get a key-value pair from the [`Memtable`].
+    /// Get a value pair from the [`Memtable`].
     pub fn get(&self, key: &[u8]) -> Option<&[u8]> {
         match self.tree.get(key) {
             Some(Some(v)) => Some(v),

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -4,7 +4,7 @@
 use std::{
     collections::BTreeMap,
     fs::File,
-    io::{BufRead, BufReader, Write},
+    io::{BufRead, BufReader},
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
 };

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -4,7 +4,7 @@
 use std::{
     collections::BTreeMap,
     fs::File,
-    io::{BufRead, BufReader},
+    io::{BufRead, BufReader, Write},
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
 };
@@ -121,8 +121,8 @@ impl Memtable {
     }
 
     /// Load a [`Memtable`]'s contained data by providing its path.
-    pub fn load(path: PathBuf) -> BTreeMap<Bytes, Bytes> {
-        println!("Loading from {path:?}");
+    pub fn load(path: PathBuf) -> BTreeMap<Bytes, Option<Bytes>> {
+        eprintln!("Loading from {path:?}");
         let data = std::fs::read(&path).unwrap();
         bincode::deserialize(&data).unwrap()
     }
@@ -169,8 +169,8 @@ mod test {
 
         let data = Memtable::load(flush_dir.path().join("sstable-0"));
         assert_eq!(
-            data.get(b"foo".as_ref()),
-            Some(&bytes::Bytes::from_static(b"bar"))
+            *data.get(b"foo".as_ref()).unwrap(),
+            Some(bytes::Bytes::from_static(b"bar"))
         );
     }
 

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -57,6 +57,11 @@ impl Memtable {
 
     /// Put a key-value pair into the [`Memtable`].
     pub fn put(&mut self, key: Vec<u8>, value: Vec<u8>) {
+        eprintln!(
+            "Inserting {}={}",
+            String::from_utf8_lossy(&key),
+            String::from_utf8_lossy(&value)
+        );
         let key = Bytes::from(key);
         let value = Bytes::from(value);
         self.approximate_size

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -18,7 +18,7 @@ pub const MEMTABLE_MAX_SIZE_BYTES: u64 = 1048576; // 1 MiB
 #[derive(Debug)]
 pub struct Memtable {
     id: AtomicU64,
-    tree: BTreeMap<Bytes, Bytes>,
+    tree: BTreeMap<Bytes, Option<Bytes>>,
 
     /// Approximate size of the [`Memtable`]. This is an approximation as it simply
     /// uses the values to increment size - simply because for most cases the values
@@ -37,7 +37,7 @@ impl Memtable {
         }
     }
 
-    pub fn load<P: AsRef<Path>>(&mut self, wal: Wal<P>) {
+    pub fn restore<P: AsRef<Path>>(&mut self, wal: Wal<P>) {
         let wal_file = File::open(wal.path()).expect("File from given WAL should exist");
         let reader = BufReader::new(wal_file);
 
@@ -46,17 +46,17 @@ impl Memtable {
             let entry: WalEntry = bincode::deserialize(line.as_bytes()).unwrap();
             match entry {
                 WalEntry::Put { key, value } => {
-                    self.tree.insert(key.into(), value.into());
+                    self.tree.insert(key.into(), Some(value.into()));
                 }
                 WalEntry::Delete { key } => {
-                    self.tree.remove(&*key);
+                    self.tree.insert(key.into(), None);
                 }
             }
         }
     }
 
     /// Put a key-value pair into the [`Memtable`].
-    pub fn put(&mut self, key: Vec<u8>, value: Vec<u8>) {
+    pub fn insert(&mut self, key: Vec<u8>, value: Vec<u8>) {
         eprintln!(
             "Inserting {}={}",
             String::from_utf8_lossy(&key),
@@ -66,24 +66,20 @@ impl Memtable {
         let value = Bytes::from(value);
         self.approximate_size
             .fetch_add(value.len() as u64, Ordering::Acquire);
-        self.tree.insert(key, value);
+        self.tree.insert(key, Some(value));
     }
 
     /// Get a key-value pair from the [`Memtable`].
     pub fn get(&self, key: &[u8]) -> Option<&[u8]> {
         match self.tree.get(key) {
-            Some(v) => Some(v),
-            None => None,
+            Some(Some(v)) => Some(v),
+            Some(None) | None => None, // Tombstone or nonexistent
         }
     }
 
     /// Delete a key-value pair from the [`Memtable`].
-    /// The key must exist in order to be deleted.
-    pub fn delete(&mut self, key: &[u8]) -> Result<(), &'static str> {
-        match self.tree.remove(key) {
-            Some(_) => Ok(()),
-            None => Err("cannot remove nonexistent key"),
-        }
+    pub fn delete(&mut self, key: Vec<u8>) {
+        self.tree.insert(key.into(), None);
     }
 
     /// Write the [`Memtable`] to disk, this then becomes a Sorted String Table
@@ -124,12 +120,17 @@ impl Memtable {
     pub fn len(&self) -> u64 {
         self.tree.len() as u64
     }
+
+    /// Load a [`Memtable`]'s contained data by providing its path.
+    pub fn load(path: PathBuf) -> BTreeMap<Bytes, Bytes> {
+        println!("Loading from {path:?}");
+        let data = std::fs::read(&path).unwrap();
+        bincode::deserialize(&data).unwrap()
+    }
 }
 
 #[cfg(test)]
 mod test {
-    use std::collections::BTreeMap;
-
     use tempdir::TempDir;
 
     use crate::wal::{Wal, WalEntry, WAL_MAX_SIZE_BYTES};
@@ -141,7 +142,7 @@ mod test {
     #[test]
     fn crud_operations() {
         let mut m = Memtable::new(0, MEMTABLE_MAX_SIZE_BYTES);
-        m.put(b"foo".to_vec(), b"bar".to_vec());
+        m.insert(b"foo".to_vec(), b"bar".to_vec());
 
         assert_eq!(
             m.get(b"foo"),
@@ -149,16 +150,15 @@ mod test {
             "Expected key to exist after put"
         );
 
-        assert!(m.delete(b"foo").is_ok());
+        m.delete(b"foo".to_vec());
         assert!(m.get(b"foo").is_none());
-        assert!(m.delete(b"foo").is_err());
     }
 
     #[test]
     fn flush_to_sstable() {
         let mut m = Memtable::new(0, MEMTABLE_MAX_SIZE_BYTES);
         let flush_dir = TempDir::new("flush").unwrap();
-        m.put(b"foo".to_vec(), b"bar".to_vec());
+        m.insert(b"foo".to_vec(), b"bar".to_vec());
         assert_eq!(
             m.size(),
             b"bar".len() as u64,
@@ -200,7 +200,7 @@ mod test {
         }
 
         let mut m = Memtable::new(0, MEMTABLE_MAX_SIZE_BYTES);
-        m.load(wal);
+        m.restore(wal);
 
         for i in 0..10 {
             match i {

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -79,6 +79,7 @@ impl Memtable {
 
     /// Delete a key-value pair from the [`Memtable`].
     pub fn delete(&mut self, key: Vec<u8>) {
+        eprintln!("Deleting {}", String::from_utf8_lossy(&key));
         self.tree.insert(key.into(), None);
     }
 

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -62,6 +62,7 @@ impl<P: AsRef<Path>> Wal<P> {
         self.current_size += size;
 
         if self.current_size > self.max_size {
+            eprintln!("WAL rotation");
             // Create a new wal file
             self.rotate()
         }
@@ -88,6 +89,7 @@ impl<P: AsRef<Path>> Wal<P> {
             .open(self.log_directory.as_ref().join(format!("{new_id}.wal")))
             .expect("Can rotate WAL file");
 
+        self.current_size = 0;
         self.log_file = log_file;
     }
 
@@ -176,6 +178,7 @@ mod test {
                 value: b"bar".to_vec(),
             });
         }
+        assert_eq!(wal.current_size, 0, "WAL size should reset");
         assert_ne!(
             wal.id.load(Ordering::Acquire),
             0,


### PR DESCRIPTION
Add very basic compaction strategy which reads from all current SSTables (L1) and writes them into a larger L2 tree. Tombstones values are implicitly ignored as a value is an `Option`.