### PR TITLE
feat: wal segments

### DIFF
--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -75,7 +75,7 @@ impl<P: AsRef<Path> + Clone> Lsm<P> {
             value: value.to_vec(),
         };
 
-        self.wal.append(entry);
+        self.wal.append(vec![entry]);
 
         self.memtable.insert(key, value);
         if self.memtable.size() > self.memtable_config.max_size {
@@ -165,7 +165,7 @@ impl<P: AsRef<Path> + Clone> Lsm<P> {
     }
 
     pub fn delete(&mut self, key: Vec<u8>) {
-        self.wal.append(WalEntry::Delete { key: key.clone() });
+        self.wal.append(vec![WalEntry::Delete { key: key.clone() }]);
         self.memtable.delete(key);
     }
 

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -274,7 +274,6 @@ mod test {
         lsm.force_compaction();
         let post_compaction_size = dir_size();
 
-        println!("Post: {post_compaction_size}, Final: {final_size}");
         assert!(post_compaction_size < final_size);
         assert_ne!(
             lsm.memtable_id(),

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -5,7 +5,7 @@ use std::{
     collections::BTreeMap,
     fs::File,
     io::{BufRead, BufReader},
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::atomic::{AtomicU64, Ordering},
 };
 
@@ -37,7 +37,7 @@ impl Memtable {
         }
     }
 
-    pub fn restore<P: AsRef<Path>>(&mut self, wal: Wal<P>) {
+    pub fn restore(&mut self, wal: Wal) {
         let wal_file = File::open(wal.path()).expect("File from given WAL should exist");
         let reader = BufReader::new(wal_file);
 
@@ -133,7 +133,7 @@ impl Memtable {
 mod test {
     use tempdir::TempDir;
 
-    use crate::wal::{Wal, WalEntry, WAL_MAX_SIZE_BYTES};
+    use crate::wal::{Wal, WalEntry, WAL_MAX_SEGMENT_SIZE_BYTES};
 
     use super::{Memtable, MEMTABLE_MAX_SIZE_BYTES};
 
@@ -179,7 +179,7 @@ mod test {
     fn wal_replay() {
         let wal_dir = TempDir::new("replay").unwrap();
 
-        let mut wal = Wal::new(0, wal_dir, WAL_MAX_SIZE_BYTES);
+        let mut wal = Wal::new(0, wal_dir.into_path(), WAL_MAX_SEGMENT_SIZE_BYTES);
         for i in 0..10 {
             match i {
                 0 | 3 | 6 => wal.append(vec![WalEntry::Delete {

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -182,16 +182,16 @@ mod test {
         let mut wal = Wal::new(0, wal_dir, WAL_MAX_SIZE_BYTES);
         for i in 0..10 {
             match i {
-                0 | 3 | 6 => wal.append(WalEntry::Delete {
+                0 | 3 | 6 => wal.append(vec![WalEntry::Delete {
                     key: format!("key{i}").as_bytes().to_vec(),
-                }),
+                }]),
                 _ => {
                     let key = format!("key{i}");
                     let value = format!("value{i}");
-                    wal.append(WalEntry::Put {
+                    wal.append(vec![WalEntry::Put {
                         key: key.as_bytes().to_vec(),
                         value: value.as_bytes().to_vec(),
-                    })
+                    }])
                 }
             };
         }

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -112,8 +112,9 @@ impl Wal {
         eprintln!("WAL rotation");
         self.segment.flush();
 
-        self.closed_segments.push(self.segment.id());
-        let new_segment = Segment::new(self.segment.id() + 1, self.log_directory.clone());
+        let current_id = self.segment.id();
+        self.closed_segments.push(current_id);
+        let new_segment = Segment::new(current_id + 1, self.log_directory.clone());
         self.current_size = 0;
         self.segment = new_segment;
     }

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -209,9 +209,15 @@ mod test {
                 value: b"bar".to_vec(),
             }]);
         }
+
+        assert_eq!(wal.closed_segments.len(), 0, "No closed segments");
+        assert_eq!(wal.segment.id(), 0);
+
         wal.rotate();
+
         assert_eq!(wal.current_size, 0, "WAL size should reset");
         assert_ne!(wal.segment.id(), 0, "WAL rotation has not occurred");
+        assert_eq!(wal.closed_segments.len(), 1);
         assert_eq!(wal.segment.id(), 1);
     }
 }

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -16,7 +16,6 @@ pub struct Wal<P: AsRef<Path>> {
     id: AtomicU64,
     log_file: File,
     log_directory: P,
-    log_file_path: PathBuf,
     current_size: u64,
     max_size: u64,
 }
@@ -46,7 +45,6 @@ impl<P: AsRef<Path>> Wal<P> {
         Self {
             id,
             log_file,
-            log_file_path: PathBuf::from(log_file_path),
             log_directory,
             current_size: 0,
             max_size,
@@ -65,8 +63,13 @@ impl<P: AsRef<Path>> Wal<P> {
     }
 
     /// Get the current path of the WAL file.
-    pub fn path(&self) -> &Path {
-        &self.log_file_path
+    pub fn path(&self) -> PathBuf {
+        format!(
+            "{}/{}.wal",
+            self.log_directory.as_ref().display(),
+            self.id.load(std::sync::atomic::Ordering::Acquire)
+        )
+        .into()
     }
 
     /// Rotate the current WAL file.

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -2,23 +2,66 @@
 #![allow(dead_code)]
 
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use std::{fs::File, sync::atomic::AtomicU64};
 
 use serde::{Deserialize, Serialize};
 
-pub const WAL_MAX_SIZE_BYTES: u64 = 1048576; // 1 MiB
+pub const WAL_MAX_SEGMENT_SIZE_BYTES: u64 = 64 * 1024 * 1024; // 64 MiB
 
 /// Wal maintains a write-ahead log (WAL) as an append-only file to provide persistence
 /// across crashes of the system.
-pub struct Wal<P: AsRef<Path>> {
-    id: AtomicU64,
-    log_file: File,
-    log_directory: P,
+pub struct Wal {
+    log_directory: PathBuf,
     current_size: u64,
     max_size: u64,
     buffer: Vec<u8>,
+
+    /// Closed, immutable WAL segment IDs.
+    ///
+    /// Once the incoming WAL that was placed into a memtable has subsequently
+    /// been flushed to an SSTable, these can be safely archived or deleted.
+    closed_segments: Vec<u64>,
+
+    /// Active segment file
+    segment: Segment,
+}
+
+struct Segment {
+    /// ID of the segment.
+    id: AtomicU64,
+    log_file: File,
+}
+
+impl Segment {
+    pub fn new(id: u64, path: PathBuf) -> Self {
+        let id = AtomicU64::new(id);
+        let log_file_path = format!(
+            "{}/{}.wal",
+            path.display(),
+            id.load(std::sync::atomic::Ordering::Acquire)
+        );
+        let new_segment = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(log_file_path)
+            .unwrap();
+
+        Self {
+            id,
+            log_file: new_segment,
+        }
+    }
+
+    pub fn flush(&mut self) {
+        self.log_file.sync_all().unwrap()
+    }
+
+    // The current WAL id.
+    pub fn id(&self) -> u64 {
+        self.id.load(Ordering::Acquire)
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -27,29 +70,15 @@ pub enum WalEntry {
     Delete { key: Vec<u8> },
 }
 
-impl<P: AsRef<Path>> Wal<P> {
-    pub fn new(id: u64, log_directory: P, max_size: u64) -> Self {
-        let id = AtomicU64::new(id);
-        let log_file_path = format!(
-            "{}/{}.wal",
-            log_directory.as_ref().display(),
-            id.load(std::sync::atomic::Ordering::Acquire)
-        );
-
-        let log_file = std::fs::File::options()
-            .create(true)
-            .append(true)
-            .read(true)
-            .open(&log_file_path)
-            .expect("Can create new WAL file");
-
+impl Wal {
+    pub fn new(id: u64, log_directory: PathBuf, max_size: u64) -> Self {
         Self {
-            id,
-            log_file,
-            log_directory,
+            log_directory: log_directory.clone(),
             current_size: 0,
             max_size,
             buffer: Vec::new(),
+            segment: Segment::new(id, log_directory),
+            closed_segments: Vec::new(),
         }
     }
 
@@ -66,49 +95,27 @@ impl<P: AsRef<Path>> Wal<P> {
             bincode::serialize_into(&mut self.buffer, &e).unwrap();
             writeln!(&mut self.buffer).unwrap();
         }
-        self.log_file.write_all(&self.buffer).unwrap();
+        self.segment.log_file.write_all(&self.buffer).unwrap();
         self.current_size = self.buffer.len() as u64;
         self.buffer.len() as u64
     }
 
-    /// Get the current path of the WAL file.
+    /// Get the current path of the active WAL segment file.
     pub fn path(&self) -> PathBuf {
-        format!(
-            "{}/{}.wal",
-            self.log_directory.as_ref().display(),
-            self.id.load(std::sync::atomic::Ordering::Acquire)
-        )
-        .into()
+        format!("{}/{}.wal", self.log_directory.display(), self.segment.id()).into()
     }
 
-    /// Rotate the current WAL file.
+    /// Rotate the currently active WAL segment file.
     ///
     /// This flushes all operations to the current file before creating a new file.
     pub fn rotate(&mut self) {
         eprintln!("WAL rotation");
-        self.log_file.sync_all().unwrap();
+        self.segment.flush();
 
-        let new_id = self.next_id();
-        let log_file = std::fs::File::options()
-            .create(true)
-            .append(true)
-            .read(true)
-            .open(self.log_directory.as_ref().join(format!("{new_id}.wal")))
-            .expect("Can rotate WAL file");
-
+        self.closed_segments.push(self.segment.id());
+        let new_segment = Segment::new(self.segment.id() + 1, self.log_directory.clone());
         self.current_size = 0;
-        self.log_file = log_file;
-    }
-
-    // The current WAL id.
-    pub fn id(&self) -> u64 {
-        self.id.load(Ordering::Acquire)
-    }
-
-    /// Set the next WAL id and return its value.
-    pub fn next_id(&self) -> u64 {
-        // This returns the previous, so we add one to it to get the new value.
-        self.id.fetch_add(1, Ordering::Acquire) + 1
+        self.segment = new_segment;
     }
 
     pub fn size(&self) -> u64 {
@@ -129,7 +136,7 @@ mod test {
     #[test]
     fn write_to_wal() {
         let temp_dir = TempDir::new("write_wal").unwrap();
-        let mut wal = Wal::new(0, &temp_dir, WAL_MAX_SIZE_BYTES);
+        let mut wal = Wal::new(0, temp_dir.path().to_path_buf(), WAL_MAX_SEGMENT_SIZE_BYTES);
 
         let entry = WalEntry::Put {
             key: b"foo".to_vec(),
@@ -156,7 +163,7 @@ mod test {
                 value: b"bar".to_vec(),
             });
         }
-        let mut wal = Wal::new(1, &temp_dir, WAL_MAX_SIZE_BYTES);
+        let mut wal = Wal::new(1, temp_dir.path().to_path_buf(), WAL_MAX_SEGMENT_SIZE_BYTES);
         let wrote = wal.append(entries);
         assert_eq!(wal.current_size, wrote);
         let wal_file = BufReader::new(std::fs::File::open(wal.path()).unwrap());
@@ -173,28 +180,19 @@ mod test {
     }
 
     #[test]
-    fn next_id() {
-        let temp_dir = TempDir::new("write_wal").unwrap();
-        let wal = Wal::new(0, temp_dir, WAL_MAX_SIZE_BYTES);
-        assert_eq!(wal.next_id(), 1);
-        assert_eq!(wal.next_id(), 2);
-    }
-
-    #[test]
     fn id() {
         let temp_dir = TempDir::new("write_wal").unwrap();
-        let wal = Wal::new(0, temp_dir, WAL_MAX_SIZE_BYTES);
-        assert_eq!(wal.id(), 0);
-        assert_eq!(wal.next_id(), 1);
+        let wal = Wal::new(0, temp_dir.into_path(), WAL_MAX_SEGMENT_SIZE_BYTES);
+        assert_eq!(wal.segment.id(), 0);
     }
 
     #[test]
     fn wal_path() {
         let temp_dir = TempDir::new("write_wal").unwrap();
-        let wal = Wal::new(0, &temp_dir, WAL_MAX_SIZE_BYTES);
+        let wal = Wal::new(0, temp_dir.path().to_path_buf(), WAL_MAX_SEGMENT_SIZE_BYTES);
         assert_eq!(
             wal.path(),
-            temp_dir.path().join("0.wal"),
+            temp_dir.into_path().join("0.wal"),
             "WAL filename was not in the expected format"
         );
     }
@@ -202,7 +200,7 @@ mod test {
     #[test]
     fn rotation() {
         let temp_dir = TempDir::new("write_wal").unwrap();
-        let mut wal = Wal::new(0, temp_dir, WAL_MAX_SIZE_BYTES);
+        let mut wal = Wal::new(0, temp_dir.into_path(), WAL_MAX_SEGMENT_SIZE_BYTES);
 
         for _ in 0..3 {
             wal.append(vec![WalEntry::Put {
@@ -212,11 +210,7 @@ mod test {
         }
         wal.rotate();
         assert_eq!(wal.current_size, 0, "WAL size should reset");
-        assert_ne!(
-            wal.id.load(Ordering::Acquire),
-            0,
-            "WAL rotation has not occurred"
-        );
-        assert_eq!(wal.id.load(Ordering::Acquire), 1);
+        assert_ne!(wal.segment.id(), 0, "WAL rotation has not occurred");
+        assert_eq!(wal.segment.id(), 1);
     }
 }


### PR DESCRIPTION
Implements a WAL over "segments". The `Segment` is the active log being written too, whilst the WAL can contain multiple closed segments.

This takes heavy inspiration from Prometheus' [`wlog`](https://github.com/prometheus/prometheus/blob/main/tsdb/wlog/wlog.go) implementation.