### PR TITLE
feat: introduce bloom filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,16 +141,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "bloomfx"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00c73937a7adc5f3acf44bc5fc1d6169a1b355e14c34d6c97b63ada55ef5767"
+dependencies = [
+ "bit-vec",
+ "fxhash",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -179,6 +201,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "bincode",
+ "bloomfx",
  "bytes",
  "chrono",
  "dashmap",
@@ -344,6 +367,15 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bloomfx"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00c73937a7adc5f3acf44bc5fc1d6169a1b355e14c34d6c97b63ada55ef5767"
+checksum = "18c11e8438d35bded62f4808e811f2d200abfd97086cc704e4bdaa76536a4d92"
 dependencies = [
  "bit-vec",
  "fxhash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 axum = "0.7.5"
 bincode = "1.3.3"
+bloomfx = "0.1.0"
 bytes = { version = "1.6.1", features = ["serde"] }
 chrono = "0.4.38"
 dashmap = { version = "6.0.1", features = ["serde"] }

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -343,6 +343,19 @@ mod test {
 
         assert!(lsm.check(b"foo".to_vec()));
         assert!(!lsm.check(b"baz".to_vec()));
+
+        drop(lsm);
+
+        let mut lsm = create_lsm(&dir, WAL_MAX_SEGMENT_SIZE_BYTES, MEMTABLE_MAX_SIZE_BYTES);
+        lsm.restore();
+        assert!(
+            lsm.check(b"foo".to_vec()),
+            "The key 'foo' should exist in the filter after the structure was restored."
+        );
+        assert!(
+            !lsm.check(b"baz".to_vec()),
+            "A value which does not exist should not appear after restore"
+        );
     }
 
     #[test]

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -308,6 +308,16 @@ mod test {
     }
 
     #[test]
+    fn bloom() {
+        let dir = TempDir::new("bloom").unwrap();
+        let mut lsm = create_lsm(&dir, WAL_MAX_SEGMENT_SIZE_BYTES, MEMTABLE_MAX_SIZE_BYTES);
+
+        lsm.insert(b"foo".to_vec(), b"bar".to_vec());
+
+        assert!(lsm.check(b"foo".to_vec()));
+    }
+
+    #[test]
     fn segment_cleanup() {
         let dir = TempDir::new("segment_cleanup").unwrap();
         let lsm = create_lsm(&dir, WAL_MAX_SEGMENT_SIZE_BYTES, MEMTABLE_MAX_SIZE_BYTES);

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -136,6 +136,15 @@ impl Memtable {
     }
 }
 
+impl IntoIterator for &Memtable {
+    type Item = (Bytes, Option<Bytes>);
+    type IntoIter = dashmap::iter::OwningIter<Bytes, Option<Bytes>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.tree.clone().into_iter()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use tempdir::TempDir;


### PR DESCRIPTION
Closes https://github.com/jdockerty/chipmunk/issues/19

Introduce a basic bloom filter to the tree for speeding up whether a key is contained within the structure.
