### PR TITLE
refactor: move restore to wal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "linux-raw-sys"
@@ -968,9 +968,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags",
  "errno",
@@ -1237,9 +1237,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -200,7 +200,8 @@ impl Lsm {
             wal.restore();
             println!("Restoring Memtable");
             for line in wal.lines() {
-                let line: WalEntry = bincode::deserialize(line.unwrap().as_bytes()).unwrap();
+                let line = line.unwrap();
+                let line: WalEntry = bincode::deserialize(line.as_bytes()).unwrap();
                 match line {
                     WalEntry::Put { key, value } => {
                         self.memtable.insert(key, value);

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -3,16 +3,12 @@
 
 use std::{
     collections::BTreeMap,
-    fs::File,
-    io::{BufRead, BufReader},
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::atomic::{AtomicU64, Ordering},
 };
 
 use bytes::Bytes;
 use dashmap::DashMap;
-
-use crate::wal::WalEntry;
 
 pub const MEMTABLE_MAX_SIZE_BYTES: u64 = 1048576; // 1 MiB
 
@@ -35,30 +31,6 @@ impl Memtable {
             tree: DashMap::new(),
             approximate_size: AtomicU64::new(0),
             max_size,
-        }
-    }
-
-    /// Restore the [`Memtable`] through reading the WAL files which are in the
-    /// provided directory.
-    pub fn restore(&mut self, dir: &Path) {
-        let wal_files = std::fs::read_dir(dir).expect("Can read set log_directory");
-        for w in wal_files {
-            let w = w.expect("Valid file within log directory");
-            let wal_file = File::open(w.path()).expect("File from given WAL should exist");
-            let reader = BufReader::new(wal_file);
-
-            for line in reader.lines() {
-                let line = line.unwrap();
-                let entry: WalEntry = bincode::deserialize(line.as_bytes()).unwrap();
-                match entry {
-                    WalEntry::Put { key, value } => {
-                        self.tree.insert(key.into(), Some(value.into()));
-                    }
-                    WalEntry::Delete { key } => {
-                        self.tree.insert(key.into(), None);
-                    }
-                }
-            }
         }
     }
 
@@ -149,8 +121,6 @@ impl IntoIterator for &Memtable {
 mod test {
     use tempdir::TempDir;
 
-    use crate::wal::{Wal, WalEntry, WAL_MAX_SEGMENT_SIZE_BYTES};
-
     use super::{Memtable, MEMTABLE_MAX_SIZE_BYTES};
 
     const TINY_MEMTABLE_BYTES: u64 = 10;
@@ -189,40 +159,5 @@ mod test {
             *data.get(b"foo".as_ref()).unwrap(),
             Some(bytes::Bytes::from_static(b"bar"))
         );
-    }
-
-    #[test]
-    fn wal_replay() {
-        let wal_dir = TempDir::new("replay").unwrap();
-
-        let mut wal = Wal::new(0, wal_dir.path(), WAL_MAX_SEGMENT_SIZE_BYTES);
-        for i in 0..10 {
-            match i {
-                0 | 3 | 6 => wal.append(vec![WalEntry::Delete {
-                    key: format!("key{i}").as_bytes().to_vec(),
-                }]),
-                _ => {
-                    let key = format!("key{i}");
-                    let value = format!("value{i}");
-                    wal.append(vec![WalEntry::Put {
-                        key: key.as_bytes().to_vec(),
-                        value: value.as_bytes().to_vec(),
-                    }])
-                }
-            };
-        }
-
-        let mut m = Memtable::new(0, MEMTABLE_MAX_SIZE_BYTES);
-        m.restore(wal_dir.path());
-
-        for i in 0..10 {
-            match i {
-                0 | 3 | 6 => assert!(m.get(format!("key{i}").as_bytes()).is_none()),
-                _ => assert_eq!(
-                    m.get(format!("key{i}").as_bytes()),
-                    Some(format!("value{i}").into_bytes())
-                ),
-            }
-        }
     }
 }

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -127,7 +127,8 @@ impl Wal {
     fn append_batch(&mut self, entries: Vec<WalEntry>) -> u64 {
         // Invariant: the buffer should be empty here as it was previously
         // cleared after appending older entries. If the buffer is not empty
-        // then we can append duplicate data, which is not desired.
+        // then we can append duplicate data which may become unbounded in size
+        // as more and more data is added.
         assert_eq!(self.buffer.len(), 0);
 
         for e in entries {

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -105,8 +105,17 @@ impl Wal {
         }
     }
 
+    /// Return a [`Lines`] iterator over the active segment file.
     pub fn lines(&self) -> Lines<BufReader<File>> {
-        BufReader::new(std::fs::File::open(&self.log_directory).unwrap()).lines()
+        let segment_path = format!(
+            "{}/{}.wal",
+            self.log_directory.display(),
+            self.segment.id.load(Ordering::Relaxed)
+        );
+        let segment_file = std::fs::File::open(&segment_path)
+            .expect("Active segment file exists within log_directory");
+
+        BufReader::new(segment_file).lines()
     }
 
     /// Append a [`WalEntry`] to the WAL file.


### PR DESCRIPTION
Refactoring the use of `restore`. Prior to this the restore functionality took place within the `Memtable`, which didn't make much sense because the memtable should have no knowledge of the WAL.

Instead, this moves the `restore` as part of the `Wal` as this is really about restoring a segment. This then exposes the necessary functionality such that the restore of the LSM-tree itself can build each component as needed.