### PR TITLE
feat: add configurable wal buffer size

### DIFF
--- a/src/bin/chipmunk.rs
+++ b/src/bin/chipmunk.rs
@@ -11,6 +11,7 @@ async fn main() {
             id: 0,
             max_size: 1024,
             log_directory: "./".into(),
+            buffer_size: None,
         },
         memtable: MemtableConfig {
             id: 0,

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,14 +5,16 @@ pub struct WalConfig {
     pub id: u64,
     pub max_size: u64,
     pub log_directory: PathBuf,
+    pub buffer_size: Option<usize>,
 }
 
 impl WalConfig {
-    pub fn new(id: u64, max_size: u64, log_directory: PathBuf) -> Self {
+    pub fn new(id: u64, max_size: u64, log_directory: PathBuf, buffer_size: Option<usize>) -> Self {
         Self {
             id,
             max_size,
             log_directory,
+            buffer_size,
         }
     }
 }

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -46,6 +46,7 @@ impl Lsm {
                 wal_config.id,
                 &wal_config.log_directory,
                 wal_config.max_size,
+                wal_config.buffer_size,
             )
             .into(),
             memtable: Memtable::new(memtable_config.id, memtable_config.max_size),
@@ -306,6 +307,7 @@ mod test {
             id: 0,
             max_size: wal_max_size,
             log_directory: dir.path().to_path_buf(),
+            buffer_size: None,
         };
         let m = MemtableConfig {
             id: 0,

--- a/src/server.rs
+++ b/src/server.rs
@@ -104,7 +104,7 @@ mod test {
     async fn chipmunk_invalid_add() {
         let dir = TempDir::new("invalid_post").unwrap();
         let conf = ChipmunkConfig {
-            wal: WalConfig::new(0, 1024, dir.path().to_path_buf()),
+            wal: WalConfig::new(0, 1024, dir.path().to_path_buf(), None),
             memtable: MemtableConfig::new(0, 1024),
         };
         let addr = setup_server(conf).await;
@@ -123,7 +123,7 @@ mod test {
     async fn chipmunk_crud() {
         let dir = TempDir::new("write_kv").unwrap();
         let conf = ChipmunkConfig {
-            wal: WalConfig::new(0, 1024, dir.path().to_path_buf()),
+            wal: WalConfig::new(0, 1024, dir.path().to_path_buf(), None),
             memtable: MemtableConfig::new(0, 1024),
         };
         let addr = setup_server(conf).await;

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -12,6 +12,10 @@ use crate::ChipmunkError;
 
 pub const WAL_MAX_SEGMENT_SIZE_BYTES: u64 = 64 * 1024 * 1024; // 64 MiB
 
+// Taken from the Rust [sys_common](https://doc.rust-lang.org/src/std/sys_common/io.rs.html#3)
+// crate for a sane default size.
+const DEFAULT_BUFFER_SIZE: usize = 8 * 1024;
+
 /// Wal maintains a write-ahead log (WAL) as an append-only file to provide persistence
 /// across crashes of the system.
 pub struct Wal {
@@ -79,8 +83,6 @@ pub enum WalEntry {
     Put { key: Vec<u8>, value: Vec<u8> },
     Delete { key: Vec<u8> },
 }
-
-const DEFAULT_BUFFER_SIZE: usize = 8 * 1024;
 
 impl Wal {
     pub fn new(id: u64, log_directory: &Path, max_size: u64, buffer_size: Option<usize>) -> Self {

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -80,13 +80,21 @@ pub enum WalEntry {
     Delete { key: Vec<u8> },
 }
 
+const DEFAULT_BUFFER_SIZE: usize = 8 * 1024;
+
 impl Wal {
-    pub fn new(id: u64, log_directory: &Path, max_size: u64) -> Self {
+    pub fn new(id: u64, log_directory: &Path, max_size: u64, buffer_size: Option<usize>) -> Self {
+        let buf = if let Some(size) = buffer_size {
+            Vec::with_capacity(size)
+        } else {
+            Vec::with_capacity(DEFAULT_BUFFER_SIZE)
+        };
+
         Self {
             log_directory: log_directory.to_path_buf(),
             current_size: 0,
             max_size,
-            buffer: Vec::new(),
+            buffer: buf,
             segment: Segment::try_new(id, log_directory).unwrap(),
             closed_segments: Vec::new(),
         }

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -247,7 +247,7 @@ mod test {
     #[test]
     fn write_to_wal() {
         let temp_dir = TempDir::new("write_wal").unwrap();
-        let mut wal = Wal::new(0, temp_dir.path(), WAL_MAX_SEGMENT_SIZE_BYTES);
+        let mut wal = Wal::new(0, temp_dir.path(), WAL_MAX_SEGMENT_SIZE_BYTES, None);
 
         let wrote = wal.append_batch(put_entries()).unwrap();
         assert_eq!(wal.current_size, wrote);
@@ -270,7 +270,7 @@ mod test {
                 value: b"bar".to_vec(),
             });
         }
-        let mut wal = Wal::new(1, temp_dir.path(), WAL_MAX_SEGMENT_SIZE_BYTES);
+        let mut wal = Wal::new(1, temp_dir.path(), WAL_MAX_SEGMENT_SIZE_BYTES, None);
         let wrote = wal.append_batch(entries).unwrap();
         assert_eq!(wal.current_size, wrote);
         let wal_file = BufReader::new(std::fs::File::open(wal.path()).unwrap());
@@ -289,7 +289,7 @@ mod test {
     #[test]
     fn wal_replay() {
         let temp_dir = TempDir::new("write_wal").unwrap();
-        let mut wal = Wal::new(0, temp_dir.path(), WAL_MAX_SEGMENT_SIZE_BYTES);
+        let mut wal = Wal::new(0, temp_dir.path(), WAL_MAX_SEGMENT_SIZE_BYTES, None);
 
         let mut wrote = 0;
         for i in 0..10 {
@@ -318,7 +318,7 @@ mod test {
         // Drop the WAL and perform a restore
         drop(wal);
 
-        let mut wal = Wal::new(0, temp_dir.path(), WAL_MAX_SEGMENT_SIZE_BYTES);
+        let mut wal = Wal::new(0, temp_dir.path(), WAL_MAX_SEGMENT_SIZE_BYTES, None);
         wal.restore().unwrap();
         assert_eq!(
             wal.current_size, wrote,
@@ -329,14 +329,14 @@ mod test {
     #[test]
     fn id() {
         let temp_dir = TempDir::new("write_wal").unwrap();
-        let wal = Wal::new(0, temp_dir.path(), WAL_MAX_SEGMENT_SIZE_BYTES);
+        let wal = Wal::new(0, temp_dir.path(), WAL_MAX_SEGMENT_SIZE_BYTES, None);
         assert_eq!(wal.segment.id(), 0);
     }
 
     #[test]
     fn wal_path() {
         let temp_dir = TempDir::new("write_wal").unwrap();
-        let wal = Wal::new(0, temp_dir.path(), WAL_MAX_SEGMENT_SIZE_BYTES);
+        let wal = Wal::new(0, temp_dir.path(), WAL_MAX_SEGMENT_SIZE_BYTES, None);
         assert_eq!(
             wal.path(),
             temp_dir.into_path().join("0.wal"),
@@ -347,7 +347,7 @@ mod test {
     #[test]
     fn rotation() {
         let temp_dir = TempDir::new("write_wal").unwrap();
-        let mut wal = Wal::new(0, temp_dir.path(), WAL_MAX_SEGMENT_SIZE_BYTES);
+        let mut wal = Wal::new(0, temp_dir.path(), WAL_MAX_SEGMENT_SIZE_BYTES, None);
 
         for _ in 0..3 {
             wal.append(WalEntry::Put {


### PR DESCRIPTION
Add configurable buffer size to WAL. This adds a new `DEFAULT_BUFFER_SIZE` too, which is taken from the internal Rust `BufWriter` implementation for a sane default internal buffer size when a value is not provided.

This also bundles in the moving of the `impl Wal` next to its `struct` declaration.
