### PR TITLE
chore: swap to fxhash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "bytes",
  "chrono",
  "dashmap",
+ "fxhash",
  "parking_lot",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ bloomfx = "0.1.0"
 bytes = { version = "1.6.1", features = ["serde"] }
 chrono = "0.4.38"
 dashmap = { version = "6.0.1", features = ["serde"] }
+fxhash = "0.2.1"
 parking_lot = "0.12.3"
 serde = { version = "1.0.204", features = ["derive"] }
 thiserror = "1.0.64"

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code)]
 
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU64;
 
 use bloomfx::BloomFilter;
 use bytes::Bytes;
+use fxhash::FxHashMap;
 use parking_lot::Mutex;
 
 use crate::{
@@ -118,7 +118,7 @@ impl Lsm {
     /// on disk and merging them into new files, removing any tombstones values
     /// to ensure only the most recent data is kept.
     pub fn force_compaction(&self) {
-        let mut l2_tree: BTreeMap<Bytes, Bytes> = BTreeMap::new();
+        let mut l2_tree: FxHashMap<Bytes, Bytes> = FxHashMap::default();
         let mut insert_count = 0;
         let mut skip_count = 0;
         {
@@ -126,7 +126,7 @@ impl Lsm {
             for l1_file_id in &*sstables {
                 let l1_file = self.working_directory.join(format!("sstable-{l1_file_id}"));
                 eprintln!("Compacting L1 file: {l1_file:?}");
-                let tree: BTreeMap<Bytes, Option<Bytes>> = Memtable::load(l1_file.clone());
+                let tree: FxHashMap<Bytes, Option<Bytes>> = Memtable::load(l1_file.clone());
 
                 for (k, v) in tree {
                     if let Some(v) = v {

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -2,13 +2,13 @@
 #![allow(dead_code)]
 
 use std::{
-    collections::BTreeMap,
     path::PathBuf,
     sync::atomic::{AtomicU64, Ordering},
 };
 
 use bytes::Bytes;
 use dashmap::DashMap;
+use fxhash::FxHashMap;
 
 pub const MEMTABLE_MAX_SIZE_BYTES: u64 = 1048576; // 1 MiB
 
@@ -101,7 +101,7 @@ impl Memtable {
     }
 
     /// Load a [`Memtable`]'s contained data by providing its path.
-    pub fn load(path: PathBuf) -> BTreeMap<Bytes, Option<Bytes>> {
+    pub fn load(path: PathBuf) -> FxHashMap<Bytes, Option<Bytes>> {
         eprintln!("Loading from {path:?}");
         let data = std::fs::read(&path).unwrap();
         bincode::deserialize(&data).unwrap()


### PR DESCRIPTION
Use `fxhash` instead of `BTreeMap`.

[Ref](https://nnethercote.github.io/perf-book/hashing.html)