### PR TITLE
feat: tracing usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,8 @@ dependencies = [
  "tempdir",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "walkdir",
 ]
 
@@ -614,6 +616,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +706,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +782,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1136,6 +1160,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,6 +1305,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,7 +1428,19 @@ checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1395,6 +1450,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1440,6 +1521,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ parking_lot = "0.12.3"
 serde = { version = "1.0.204", features = ["derive"] }
 thiserror = "1.0.64"
 tokio = { version = "1.39.3", features = ["full"] }
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
 
 [dev-dependencies]
 reqwest = "0.12.7"

--- a/src/bin/chipmunk.rs
+++ b/src/bin/chipmunk.rs
@@ -3,9 +3,14 @@ use chipmunk::{
     server::Chipmunk,
 };
 use tokio::net::TcpListener;
+use tracing::info;
 
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::level_filters::LevelFilter::DEBUG)
+        .init();
+
     let config = ChipmunkConfig {
         wal: WalConfig {
             id: 0,
@@ -20,7 +25,7 @@ async fn main() {
     };
 
     let c = Chipmunk::new(config);
-    eprintln!("Listening on http://127.0.0.1:5000");
+    info!("Listening on http://127.0.0.1:5000");
     let app = chipmunk::server::new_app(c);
     let listener = TcpListener::bind("127.0.0.1:5000").await.unwrap();
     axum::serve(listener, app).await.unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,6 +4,7 @@ use axum::response::IntoResponse;
 use axum::routing::{delete, get, post};
 use axum::Router;
 use std::sync::Arc;
+use tracing::warn;
 
 use crate::config::ChipmunkConfig;
 use crate::lsm::Lsm;
@@ -35,7 +36,7 @@ async fn delete_key_handler(
     match state.store().delete(key.as_bytes().to_vec()) {
         Ok(_) => StatusCode::NO_CONTENT,
         Err(e) => {
-            eprintln!("Cannot delete '{key}': {e}");
+            warn!("Cannot delete '{key}': {e}");
             StatusCode::BAD_REQUEST
         }
     }
@@ -46,7 +47,7 @@ async fn add_kv_handler(State(state): State<Arc<Chipmunk>>, req: String) -> impl
         Some((key, value)) => match state.store().insert(key.into(), value.into()) {
             Ok(_) => StatusCode::NO_CONTENT.into_response(),
             Err(e) => {
-                eprintln!("Cannot insert '{key}': {e}");
+                warn!("Cannot insert '{key}': {e}");
                 let err = format!("Cannot insert '{key}'");
                 (StatusCode::BAD_REQUEST, err).into_response()
             }

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::Ordering;
 use std::{fs::File, sync::atomic::AtomicU64};
 
 use serde::{Deserialize, Serialize};
-use tracing::{debug, info};
+use tracing::{debug, error, info};
 
 use crate::ChipmunkError;
 
@@ -90,7 +90,7 @@ impl Wal {
                 match bincode::deserialize(line.as_bytes()) {
                     Ok(entry) => buf.push(entry),
                     // Invalid entries are skipped and not restored
-                    Err(e) => eprintln!("Invalid entry in segment: {e}"),
+                    Err(e) => error!(error=%e, "Invalid entry in segment"),
                 }
             }
             info!(bytes_read, current_segment = i, "Completed segment");

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::Ordering;
 use std::{fs::File, sync::atomic::AtomicU64};
 
 use serde::{Deserialize, Serialize};
-use tracing::{debug, error, info};
+use tracing::{error, info};
 
 use crate::ChipmunkError;
 
@@ -63,8 +63,7 @@ impl Wal {
                 path: self.log_directory.clone(),
             }
         })?;
-        let num_files = segment_files.size_hint().1.expect("Upper bound exists");
-        debug!(num_files, "Segment files");
+
         for (i, s) in segment_files.into_iter().enumerate() {
             let segment = s.expect("Valid file within log directory");
             let segment_file = File::open(segment.path()).map_err(ChipmunkError::SegmentOpen)?;
@@ -73,7 +72,6 @@ impl Wal {
             info!(
                 segment_size = max_bytes,
                 current_segment_number = i,
-                number_of_segments = num_files,
                 "Restoring segment"
             );
             let reader = BufReader::new(segment_file);


### PR DESCRIPTION
Usage of the `tracing` crate to replace calls to `eprintln!` and `println!`. This provides a much more versatile logging solution.