### PR TITLE
feat: add functionality to remove closed segment files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,16 +13,16 @@ mod wal;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ChipmunkError {
-    #[error("an invalid segment file")]
-    InvalidSegment { name: String, source: io::Error },
-
-    #[error("unable to fsync the current segment")]
+    #[error("unable to fsync the current wal segment: {0}")]
     SegmentFsync(io::Error),
 
-    #[error("unable to open wal file")]
+    #[error("unable to open wal segment file: {0}")]
     SegmentOpen(io::Error),
 
-    #[error("could not append to the WAL segment")]
+    #[error("unable to delete closed segment: {0}")]
+    SegmentDelete(io::Error),
+
+    #[error("could not append to the WAL segment: {0}")]
     WalAppend(io::Error),
 
     #[error("unable to open WAL directory '{path}': {source} ")]

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -19,6 +19,7 @@ const DEFAULT_BUFFER_SIZE: usize = 8 * 1024;
 
 /// Wal maintains a write-ahead log (WAL) as an append-only file to provide persistence
 /// across crashes of the system.
+#[derive(Debug)]
 pub struct Wal {
     log_directory: PathBuf,
     current_size: u64,
@@ -202,8 +203,24 @@ impl Wal {
     pub fn clear_segments(&mut self) {
         self.closed_segments.clear();
     }
+
+    /// Remove closed segments and return the number of segments that were
+    /// removed.
+    pub fn remove_closed_segments(&mut self) -> Result<u64, ChipmunkError> {
+        let segments = self.closed_segments();
+        let mut cleared = 0;
+
+        for s in segments {
+            let segment_path = format!("{}/{}.wal", self.log_directory.display(), s);
+            std::fs::remove_file(&segment_path).map_err(ChipmunkError::SegmentDelete)?;
+            cleared += 1;
+        }
+        self.clear_segments();
+        Ok(cleared)
+    }
 }
 
+#[derive(Debug)]
 struct Segment {
     /// ID of the segment.
     id: AtomicU64,


### PR DESCRIPTION
Segments would previously remain on disk indefinitely.

This exposes the functionality to remove the closed segments.
