### PR TITLE
refactor: remove bincode from wal write path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,7 @@ dependencies = [
  "axum",
  "bincode",
  "bloomfx",
+ "byteorder",
  "bytes",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ default-run = "chipmunk"
 axum = "0.7.5"
 bincode = "1.3.3"
 bloomfx = "0.1.0"
+byteorder = "1.5.0"
 bytes = { version = "1.6.1", features = ["serde"] }
 chrono = "0.4.38"
 clap = { version = "4.5.20", features = ["derive"] }

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -249,8 +249,8 @@ impl Lsm {
             for line in wal.lines()? {
                 match line {
                     Ok(line) => {
-                        let line: WalEntry = WalEntry::from_bytes(line.as_bytes());
-                        match line {
+                        let entry: WalEntry = WalEntry::from_bytes(line.as_bytes());
+                        match entry {
                             WalEntry::Put { key, value } => {
                                 self.memtable.insert(key, value);
                             }

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -248,7 +248,7 @@ impl Lsm {
             info!("Restoring Memtable");
             // Skip 1 line for the WAL header in this file which has been verified
             // to exist
-            for line in wal.lines()?.skip(1) {
+            for line in wal.lines()? {
                 match line {
                     Ok(line) => {
                         let entry: WalEntry = WalEntry::from_bytes(line.as_bytes());

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -249,7 +249,7 @@ impl Lsm {
             for line in wal.lines()? {
                 match line {
                     Ok(line) => {
-                        let line: WalEntry = bincode::deserialize(line.as_bytes()).unwrap();
+                        let line: WalEntry = WalEntry::from_bytes(line.as_bytes());
                         match line {
                             WalEntry::Put { key, value } => {
                                 self.memtable.insert(key, value);

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -1,6 +1,7 @@
 // TODO: remove once used in other components
 #![allow(dead_code)]
 
+use std::fmt::Display;
 use std::io::{BufRead, BufReader, Lines, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
@@ -20,6 +21,8 @@ const DEFAULT_BUFFER_SIZE: usize = 8 * 1024;
 
 const WAL_INSERT_MARKER: u8 = 0;
 const WAL_DELETE_MARKER: u8 = 1;
+
+const WAL_HEADER: &str = "ch1";
 
 /// Wal maintains a write-ahead log (WAL) as an append-only file to provide persistence
 /// across crashes of the system.
@@ -343,6 +346,22 @@ impl WalEntry {
                 WalEntry::Delete { key }
             }
             _ => panic!("Unknown marker encountered"),
+        }
+    }
+}
+
+impl Display for WalEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Put { key, value } => {
+                write!(
+                    f,
+                    "PUT {}={}",
+                    String::from_utf8_lossy(key),
+                    String::from_utf8_lossy(value)
+                )
+            }
+            Self::Delete { key } => write!(f, "DELETE {}", String::from_utf8_lossy(key)),
         }
     }
 }

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -145,7 +145,7 @@ impl Wal {
 
         for e in entries {
             self.buffer
-                .write(&e.as_bytes())
+                .write_all(&e.as_bytes())
                 .expect("Can write known entry to buffer");
         }
         self.segment
@@ -278,16 +278,16 @@ impl WalEntry {
             Self::Put { key, value } => {
                 buf.write_u8(WAL_INSERT_MARKER).unwrap();
                 buf.write_u64::<BigEndian>(key.len() as u64).unwrap();
-                buf.write(&key).unwrap();
+                buf.write_all(key).unwrap();
                 buf.write_u64::<BigEndian>(value.len() as u64).unwrap();
-                buf.write(&value).unwrap();
-                buf.write(b"\n").unwrap();
+                buf.write_all(value).unwrap();
+                buf.write_all(b"\n").unwrap();
             }
             Self::Delete { key } => {
                 buf.write_u8(WAL_DELETE_MARKER).unwrap();
                 buf.write_u64::<BigEndian>(key.len() as u64).unwrap();
-                buf.write(&key).unwrap();
-                buf.write(b"\n").unwrap();
+                buf.write_all(key).unwrap();
+                buf.write_all(b"\n").unwrap();
             }
         }
         buf.shrink_to_fit();

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -18,9 +18,6 @@ pub const WAL_MAX_SEGMENT_SIZE_BYTES: u64 = 64 * 1024 * 1024; // 64 MiB
 // crate for a sane default size.
 const DEFAULT_BUFFER_SIZE: usize = 8 * 1024;
 
-/// Magic bytes header for the WAL file.
-const WAL_HEADER: &str = "ch1";
-
 const WAL_INSERT_MARKER: u8 = 0;
 const WAL_DELETE_MARKER: u8 = 1;
 


### PR DESCRIPTION
Helps with https://github.com/jdockerty/chipmunk/issues/39

This removes the `bincode` usage from the WAL as this format does not lend itself to writing sequentially to a file.

Instead, this writes the incoming data directly through the `byteorder` crate. The same is also true for the read portion.