### PR TITLE
feat: wal internal buffer

### DIFF
--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -300,6 +300,15 @@ impl Lsm {
     }
 }
 
+impl Drop for Lsm {
+    fn drop(&mut self) {
+        self.wal
+            .lock()
+            .flush_buffer()
+            .expect("Flushing buffer on drop");
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::path::Path;

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -246,8 +246,6 @@ impl Lsm {
 
             wal.restore()?;
             info!("Restoring Memtable");
-            // Skip 1 line for the WAL header in this file which has been verified
-            // to exist
             for line in wal.lines()? {
                 match line {
                     Ok(line) => {
@@ -416,14 +414,15 @@ mod test {
 
     #[test]
     fn bloom() {
+        tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .init();
         let dir = TempDir::new("bloom").unwrap();
         let lsm = create_lsm(0, &dir, WAL_MAX_SEGMENT_SIZE_BYTES, MEMTABLE_MAX_SIZE_BYTES);
 
         lsm.insert(b"foo".to_vec(), b"bar".to_vec()).unwrap();
-
         assert!(lsm.check(b"foo".to_vec()));
         assert!(!lsm.check(b"baz".to_vec()));
-
         drop(lsm);
 
         let mut lsm = create_lsm(1, &dir, WAL_MAX_SEGMENT_SIZE_BYTES, MEMTABLE_MAX_SIZE_BYTES);


### PR DESCRIPTION
Part of https://github.com/jdockerty/chipmunk/issues/40

Adds a basic internal buffer to the WAL implementation. The aim is to reduce the number of syscalls, at the moment every `append` means a file write and forced `fsync` call, with a small internal buffer then this is reduced.
